### PR TITLE
Adding config files for dummy wikipedia training

### DIFF
--- a/t5x/scripts_gpu/dummy_wikipedia_config/dummy_wikipedia_seqio.py
+++ b/t5x/scripts_gpu/dummy_wikipedia_config/dummy_wikipedia_seqio.py
@@ -1,0 +1,47 @@
+# Copyright 2022 The T5X Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import seqio
+import t5.data
+from t5.data import preprocessors
+
+TaskRegistry = seqio.TaskRegistry
+
+DEFAULT_OUTPUT_FEATURES = {
+    "inputs": seqio.Feature(
+        vocabulary=t5.data.get_default_vocabulary(), add_eos=True,
+        required=False),
+    "targets": seqio.Feature(
+        vocabulary=t5.data.get_default_vocabulary(), add_eos=True)
+}
+
+# ================================ Wikipedia ===================================
+TaskRegistry.add(
+    "wikipedia_dummy",
+    source=seqio.TfdsDataSource(tfds_name="wikipedia/20190301.als:1.0.0"),
+    preprocessors=[
+        functools.partial(
+            preprocessors.rekey, key_map={
+                "inputs": None,
+                "targets": "text"
+            }),
+        seqio.preprocessors.tokenize,
+        seqio.CacheDatasetPlaceholder(),
+        preprocessors.unsupervised,
+        seqio.preprocessors.append_eos_after_trim,
+    ],
+    output_features=DEFAULT_OUTPUT_FEATURES,
+    metric_fns=[])

--- a/t5x/scripts_gpu/dummy_wikipedia_config/setup.py
+++ b/t5x/scripts_gpu/dummy_wikipedia_config/setup.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+# -*- coding: utf-8 -*-
+
+# Copyright 2022 The T5X Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from distutils.core import setup
+
+setup(name='dummy_wikipedia_seqio',
+      version='0.0.1',
+      description='Dummy Wikipedia Seqio Task',
+      author='The T5X Authors',
+     )

--- a/t5x/scripts_gpu/dummy_wikipedia_config/small_pretrain_dummy_wikipedia.gin
+++ b/t5x/scripts_gpu/dummy_wikipedia_config/small_pretrain_dummy_wikipedia.gin
@@ -1,0 +1,38 @@
+# Copyright 2022 The T5X Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __gin__ import dynamic_registration
+
+from t5x import partitioning
+
+from t5x.examples.t5 import network
+
+include "t5x/examples/gpu_t5/t5_1_1/small.gin"
+include "t5x/examples/gpu_t5/t5_1_1/adamw_opt.gin"
+include "t5x/configs/runs/pretrain_pile.gin"
+
+# Register necessary SeqIO Tasks/Mixtures.
+import t5.data.mixtures
+# Register Dummy Wikipedia Seqio Task (needed for benchmarking)
+import dummy_wikipedia_seqio
+
+MIXTURE_OR_TASK_NAME = "wikipedia_dummy"
+TASK_FEATURE_LENGTHS = {"inputs": 512, "targets": 114}
+TRAIN_STEPS = 100
+DROPOUT_RATE = 0.0
+BATCH_SIZE = 256
+USE_CACHED_TASKS=False
+
+partitioning.PjitPartitioner:
+    num_partitions=1


### PR DESCRIPTION
This MR adds three files to run T5X training with a dummy wikipedia config.

1. `small_pretrain_dummy_wikipedia.gin`: gin config
2. `dummy_wikipedia_seqio.py`: seqio config
3. `setup.py` is needed to make this a package that can be imported in the gin config

This is intended to be used to do quick "end-to-end" testing of T5X.